### PR TITLE
#27 - Fixed invalid variable name used for static error message

### DIFF
--- a/src/Exception/RegistryError.php
+++ b/src/Exception/RegistryError.php
@@ -35,7 +35,7 @@ class RegistryError extends \LogicException implements ProvisionException
 
     public static function forUninstantiableProviderClass($class): self
     {
-        return new static("Provision Provider {$provider} is not instantiable");
+        return new static("Provision Provider {$class} is not instantiable");
     }
 
     public static function forUndefinedProviderFunctions($category, $provider, array $undefinedFunctions): self


### PR DESCRIPTION
Closes #27 

Using incorrect variable name