### PR TITLE
#25 - Resolve unsafe usage new static static analysis issue

### DIFF
--- a/src/Exception/RegistryError.php
+++ b/src/Exception/RegistryError.php
@@ -6,7 +6,7 @@ namespace Upmind\ProvisionBase\Exception;
 
 use Upmind\ProvisionBase\Exception\Contract\ProvisionException;
 
-class RegistryError extends \LogicException implements ProvisionException
+final class RegistryError extends \LogicException implements ProvisionException
 {
     public static function forInvalidCategoryClass($class): self
     {

--- a/src/Laravel/Html/HtmlField.php
+++ b/src/Laravel/Html/HtmlField.php
@@ -15,7 +15,7 @@ use Upmind\ProvisionBase\Provider\DataSet\RuleParser;
  *
  * @deprecated Use `\Upmind\ProvisionBase\Laravel\Html\FormField` instead.
  */
-class HtmlField
+final class HtmlField
 {
     /**
      * @var string[]

--- a/src/Provider/DataSet/DataSet.php
+++ b/src/Provider/DataSet/DataSet.php
@@ -17,6 +17,8 @@ use Upmind\ProvisionBase\Exception\InvalidDataSetException;
  * DTO encapsulating a data set. If the data set is invalid according to the
  * rules returned by static::rules(), an `InvalidDataSetException` will be thrown
  * for any attempt to take data from it.
+ *
+ * @phpstan-consistent-constructor
  */
 abstract class DataSet implements ArrayAccess, JsonSerializable, Arrayable, Jsonable
 {
@@ -75,7 +77,7 @@ abstract class DataSet implements ArrayAccess, JsonSerializable, Arrayable, Json
      * @param mixed[] $values Raw data
      * @param bool $autoValidation Enable or disable auto-validation of this data set instance
      */
-    final public function __construct($values = [], bool $autoValidation = true)
+    public function __construct($values = [], bool $autoValidation = true)
     {
         $this->values = $this->rawValues = (array)$this->recursiveToArray($values); // convert to raw array(s)
 

--- a/src/Provider/DataSet/DataSet.php
+++ b/src/Provider/DataSet/DataSet.php
@@ -75,7 +75,7 @@ abstract class DataSet implements ArrayAccess, JsonSerializable, Arrayable, Json
      * @param mixed[] $values Raw data
      * @param bool $autoValidation Enable or disable auto-validation of this data set instance
      */
-    public function __construct($values = [], bool $autoValidation = true)
+    final public function __construct($values = [], bool $autoValidation = true)
     {
         $this->values = $this->rawValues = (array)$this->recursiveToArray($values); // convert to raw array(s)
 

--- a/src/Provider/Helper/Exception/ConfigurationError.php
+++ b/src/Provider/Helper/Exception/ConfigurationError.php
@@ -8,6 +8,11 @@ use Upmind\ProvisionBase\Provider\Helper\Exception\Contract\ProviderError;
 
 class ConfigurationError extends \RuntimeException implements ProviderError
 {
+    final public function __construct(string $message, int $code = 0, \Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+
     public static function forMissingData(array $fieldNames): ProviderError
     {
         return new static("Configuration data missing: " . implode(', ', $fieldNames));


### PR DESCRIPTION
Closes #25 

The issue is for code protection so no calls are accidentally made with invalid params.
Can be easilly resolved either by making class `final` or by setting a `final` constructor if we need the class to be extendable. Abstract could work as well but would require further coding.

https://phpstan.org/blog/solving-phpstan-error-unsafe-usage-of-new-static

- `Upmind\ProvisionBase\Provider\Helper\Exception\ConfigurationError` is extended by custom errors. To resolve issue we set final `__construct` as we don't expect constructor to be overriden/extended
- `Upmind\ProvisionBase\Provider\DataSet\Dataset` is an abstract class extended from various Dataset types. ~~To resolve issue we set final `__construct` as we don't expect constructor to be overriden/extended~~ We added the `phpstan` docblock tag as per https://phpstan.org/blog/solving-phpstan-error-unsafe-usage-of-new-static#add-%40phpstan-consistent-constructor-to-the-class
- `Upmind\ProvisionBase\Laravel\Html\HtmlField` is deprecated and doesn't seem to be extended by anything, hence setting class as final
- `Upmind\ProvisionBase\Exception\RegistryError` similarly doesn't seem to be extended., hence setting class as final

@uphlewis to confirm if any classes extend the Dataset & RegistryError and ammend the constructor in any way.
