### PR TITLE
#54 Fix issue when Laravel application provider is loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 All notable changes to the package will be documented in this file.
 
-## Unreleased
+## v3.7.1 - 2024-02-27
 
-- Fix issue with Rule expected to be a string, while a class or callback might be provided, when a Laravel application is loaded.
+- Fix RuleParser issue with Rule expected to be a string, while a class or callback
+  might be provided, when a Laravel application is loaded
 
 ## v3.7.0 - 2023-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the package will be documented in this file.
 
+## Unreleased
+
+- Fix issue with Rule expected to be a string, while a class or callback might be provided, when a Laravel application is loaded.
+
 ## v3.7.0 - 2023-04-05
 
 - Add SystemInfo dataset to contain system/environment/runtime metadata e.g., `outgoing_ips`

--- a/src/Provider/DataSet/RuleParser.php
+++ b/src/Provider/DataSet/RuleParser.php
@@ -234,7 +234,7 @@ class RuleParser
                 return true; //exact match
             }
 
-            if ($ignoreRuleArgs) {
+            if ($ignoreRuleArgs && is_string($rule)) {
                 if (Str::startsWith($rule, Str::finish($checkRule, ':'))) {
                     return true; //match ignoring rule args
                 }


### PR DESCRIPTION
Same as #53 for v4

Our Rule Parser checker only handles string based rules.
If a native class Laravel Rule is loaded, a fatal error is thrown as the String Utility helper is executed.