### PR TITLE
#50 - DataSet Validator factory decoupling

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - 'main'
       - 'v3.7-dev'
+      - 'v5-dev'
   pull_request:
     branches:
       - 'main'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 # Workflow name
-name: Static Analysis
+name: PHP Unit Tests
 
 # Triggers
 on:
@@ -16,22 +16,22 @@ on:
 
 # Jobs/Pipelines
 jobs:
-  phpstan:
-    name: 'PHP Stan'
+  php-unit:
+    name: 'PHP Unit'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         php: [ 8.1, 8.2, 8.3 ]
     steps:
-      - name: "Checkout Code"
+      - name: 'Checkout Code'
         uses: actions/checkout@v4
 
       - name: "Setup PHP with tools"
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php }}"
-          tools: composer, phpstan
+          tools: composer
 
       - name: "Get composer cache directory"
         id: composer-cache
@@ -44,8 +44,8 @@ jobs:
           key: "${{ runner.os }}-php-${{ matrix.php}}-composer-${{ hashFiles('**/composer.json') }}"
           restore-keys: "${{ runner.os }}-php-${{ matrix.php}}-composer-"
 
-      - name: "Install Composer dependencies"
+      - name: 'Install Dependencies via Composer'
         run: composer install --no-ansi --no-interaction --no-progress --no-scripts --prefer-dist
 
-      - name: "Run PHPStan Static Analysis"
-        run: phpstan analyse
+      - name: 'Run PHPUnit'
+        run: ./vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,11 @@
 composer.lock
 vendor/
 
+# Tools
+phpunit.xml
+.phpunit.result.cache
+.phpunit.cache/
+
 # Docker
 .docker/Dockerfile
 docker-compose.yml
@@ -12,3 +17,4 @@ docker-compose.yml
 
 # System
 .DS_Store
+error_log

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ vendor/
 
 # Tools
 phpunit.xml
+phpstan.neon
 .phpunit.result.cache
 .phpunit.cache/
 

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,11 @@
             "Upmind\\ProvisionBase\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Upmind\\ProvisionBase\\Tests\\": "tests/"
+        }
+    },
     "require": {
         "php": "8.1 - 8.3",
         "guzzlehttp/guzzle": "^6.3||^7.0",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,4 +1,4 @@
 parameters:
-    level: 0
+    level: 1
     paths:
         - src

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="coverage-clover" target="clover.xml"/>
+    </logging>
+</phpunit>

--- a/src/Laravel/ProvisionServiceProvider.php
+++ b/src/Laravel/ProvisionServiceProvider.php
@@ -95,7 +95,7 @@ class ProvisionServiceProvider extends BaseProvider
         // Attempt to set the Registry instance from cache
         if ($cachedRegistry = $cache->get(self::REGISTRY_CACHE_KEY)) {
             try {
-                $registry = unserialize($cachedRegistry, ['allowed_classes' => [Registry::class]]);
+                $registry = unserialize($cachedRegistry, ['allowed_classes' => true]);
             } catch (Throwable) {
                 $registry = null;
 

--- a/src/Laravel/ProvisionServiceProvider.php
+++ b/src/Laravel/ProvisionServiceProvider.php
@@ -36,7 +36,7 @@ class ProvisionServiceProvider extends BaseProvider
         } catch (Throwable $e) {
             throw new RegistryError(
                 "Provision Category Bind Error. " . get_class($e) . ": " . $e->getMessage(),
-                intval($e->getCode()),
+                (int) $e->getCode(),
                 $e
             );
         }
@@ -95,8 +95,10 @@ class ProvisionServiceProvider extends BaseProvider
         // Attempt to set the Registry instance from cache
         if ($cachedRegistry = $cache->get(self::REGISTRY_CACHE_KEY)) {
             try {
-                $registry = unserialize($cachedRegistry);
-            } catch (Throwable $e) {
+                $registry = unserialize($cachedRegistry, ['allowed_classes' => [Registry::class]]);
+            } catch (Throwable) {
+                $registry = null;
+
                 $cache->forget(self::REGISTRY_CACHE_KEY);
             }
 

--- a/src/Laravel/Validation/ValidationHelper.php
+++ b/src/Laravel/Validation/ValidationHelper.php
@@ -2,8 +2,8 @@
 
 namespace Upmind\ProvisionBase\Laravel\Validation;
 
-use Illuminate\Support\Facades\Validator as ValidatorFactory;
 use Illuminate\Support\Str;
+use Upmind\ProvisionBase\Provider\DataSet\DataSet;
 use Upmind\ProvisionBase\Provider\DataSet\RuleParser;
 
 class ValidationHelper
@@ -15,7 +15,7 @@ class ValidationHelper
     {
         [$rule, $parameters] = RuleParser::parseRule($rule);
 
-        $validator = ValidatorFactory::make([], []);
+        $validator = DataSet::getValidatorFactory()->make([], []);
 
         if (method_exists($validator, sprintf('validate%s', Str::studly($rule)))) {
             return true; //built-in rule

--- a/src/Laravel/ValidationServiceProvider.php
+++ b/src/Laravel/ValidationServiceProvider.php
@@ -10,7 +10,6 @@ use Illuminate\Validation\Validator as LaravelValidator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
-use Illuminate\Support\Facades\Input;
 use Illuminate\Support\ServiceProvider as BaseProvider;
 use Illuminate\Support\Facades\Validator;
 use League\ISO3166\ISO3166;

--- a/src/Laravel/ValidationServiceProvider.php
+++ b/src/Laravel/ValidationServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Upmind\ProvisionBase\Laravel;
 
 use Exception;
+use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Validation\Validator as LaravelValidator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -28,9 +29,9 @@ class ValidationServiceProvider extends BaseProvider
     /**
      * Bootstrap services.
      *
-     * @return void
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
-    public function boot()
+    public function boot(): void
     {
         $this->bootCustomRules();
 
@@ -56,10 +57,17 @@ class ValidationServiceProvider extends BaseProvider
         $this->bootCertificatePemRule();
     }
 
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
     protected function bootDataSetValidatorResolver(): void
     {
-        /** @var \Illuminate\Validation\Factory $factory */
-        $factory = Validator::getFacadeRoot();
+        /** @var \Illuminate\Contracts\Validation\Factory $factory */
+        $factory = $this->app->make(Factory::class);
+
+        $this->app->resolving(DataSetValidator::class, function (DataSetValidator $validator) use ($factory) {
+            $validator->setValidatorFactory($factory);
+        });
 
         // Set Validator Factory for our DataSet classes.
         DataSet::setValidatorFactory($factory);

--- a/src/Laravel/ValidationServiceProvider.php
+++ b/src/Laravel/ValidationServiceProvider.php
@@ -149,7 +149,10 @@ class ValidationServiceProvider extends BaseProvider
                 //validate phone number for the input country code
                 $countryCode = Arr::get($validator->getData(), $parameters[0]);
 
-                $extraValidator = Validator::make([
+                /** @var \Illuminate\Contracts\Validation\Factory $factory */
+                $factory = $this->app->make(Factory::class);
+
+                $extraValidator = $factory->make([
                     'phone' => $value
                 ], [
                     'phone' => sprintf('phone:%s', $countryCode)

--- a/src/Laravel/ValidationServiceProvider.php
+++ b/src/Laravel/ValidationServiceProvider.php
@@ -24,6 +24,8 @@ use Upmind\ProvisionBase\Provider\DataSet\Validator as DataSetValidator;
  */
 class ValidationServiceProvider extends BaseProvider
 {
+    private ?Factory $validatorFactory = null;
+
     /**
      * Bootstrap services.
      *
@@ -60,8 +62,7 @@ class ValidationServiceProvider extends BaseProvider
      */
     protected function bootDataSetValidatorResolver(): void
     {
-        /** @var \Illuminate\Contracts\Validation\Factory $factory */
-        $factory = $this->app->make(Factory::class);
+        $factory = $this->getValidatorFactory();
 
         // Set Validator Factory for our DataSet classes.
         DataSet::setValidatorFactory($factory);
@@ -155,8 +156,7 @@ class ValidationServiceProvider extends BaseProvider
                 //validate phone number for the input country code
                 $countryCode = Arr::get($validator->getData(), $parameters[0]);
 
-                /** @var \Illuminate\Contracts\Validation\Factory $factory */
-                $factory = $this->app->make(Factory::class);
+                $factory = $this->getValidatorFactory();
 
                 $extraValidator = $factory->make([
                     'phone' => $value
@@ -340,5 +340,17 @@ class ValidationServiceProvider extends BaseProvider
         }
 
         return false;
+    }
+
+    /**
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    private function getValidatorFactory(): Factory
+    {
+        if ($this->validatorFactory === null) {
+            $this->validatorFactory = $this->app->make(Factory::class);
+        }
+
+        return $this->validatorFactory;
     }
 }

--- a/src/Laravel/ValidationServiceProvider.php
+++ b/src/Laravel/ValidationServiceProvider.php
@@ -11,7 +11,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\ServiceProvider as BaseProvider;
-use Illuminate\Support\Facades\Validator;
 use League\ISO3166\ISO3166;
 use libphonenumber\NumberParseException;
 use Propaganistas\LaravelPhone\Exceptions\NumberParseException as PropaganistasNumberParseException;

--- a/src/Laravel/ValidationServiceProvider.php
+++ b/src/Laravel/ValidationServiceProvider.php
@@ -64,10 +64,6 @@ class ValidationServiceProvider extends BaseProvider
         /** @var \Illuminate\Contracts\Validation\Factory $factory */
         $factory = $this->app->make(Factory::class);
 
-        $this->app->resolving(DataSetValidator::class, function (DataSetValidator $validator) use ($factory) {
-            $validator->setValidatorFactory($factory);
-        });
-
         // Set Validator Factory for our DataSet classes.
         DataSet::setValidatorFactory($factory);
 

--- a/src/Laravel/ValidationServiceProvider.php
+++ b/src/Laravel/ValidationServiceProvider.php
@@ -76,37 +76,45 @@ class ValidationServiceProvider extends BaseProvider
         });
     }
 
-    protected function bootAttributeQueryRule()
+    protected function bootAttributeQueryRule(): void
     {
-        Validator::extend(
-            AttributeQueryValidator::RULE_NAME,
-            'Upmind\ProvisionBase\Laravel\AttributeQueryValidator@validateAttributeQuery'
-        );
+        $this->app->resolving(Factory::class, function (Factory $factory) {
+            $factory->extend(
+                AttributeQueryValidator::RULE_NAME,
+                'Upmind\ProvisionBase\Laravel\AttributeQueryValidator@validateAttributeQuery'
+            );
+        });
     }
 
-    protected function bootAlphaScoreRule()
+    protected function bootAlphaScoreRule(): void
     {
         $extension = function ($attribute, $value, $parameters, $validator) {
             return !preg_match('/[^\w]/', strval($value));
         };
-        $message = 'This value must only contain letters, numbers and underscores.';
 
-        Validator::extend('alpha_score', $extension, $message);
-        Validator::extend('alpha-score', $extension, $message);
+        $this->app->resolving(Factory::class, function (Factory $factory) use ($extension) {
+            $message = 'This value must only contain letters, numbers and underscores.';
+
+            $factory->extend('alpha_score', $extension, $message);
+            $factory->extend('alpha-score', $extension, $message);
+        });
     }
 
-    protected function bootAlphaDashDotRule()
+    protected function bootAlphaDashDotRule(): void
     {
         $extension = function ($attribute, $value, $parameters, $validator) {
             return !preg_match('/[^\w\-\.]/', strval($value));
         };
-        $message = 'This value must only contain letters, numbers, dashes, underscores and periods.';
 
-        Validator::extend('alpha_dash_dot', $extension, $message);
-        Validator::extend('alpha-dash-dot', $extension, $message);
+        $this->app->resolving(Factory::class, function (Factory $factory) use ($extension,) {
+            $message = 'This value must only contain letters, numbers, dashes, underscores and periods.';
+
+            $factory->extend('alpha_dash_dot', $extension, $message);
+            $factory->extend('alpha-dash-dot', $extension, $message);
+        });
     }
 
-    protected function bootDomainNameRule()
+    protected function bootDomainNameRule(): void
     {
         $extension = function ($attribute, $value, $parameters, $validator) {
             /** @link https://stackoverflow.com/a/4694816/4741456 */
@@ -115,10 +123,14 @@ class ValidationServiceProvider extends BaseProvider
                 && preg_match('/^.{3,253}$/', $value) //overall length check
                 && preg_match('/^[^\.]{1,63}(\.[^\.]{1,63})*$/', $value); //length of each label
         };
-        $message = 'This is not a valid domain name.';
 
-        Validator::extend('domain-name', $extension, $message);
-        Validator::extend('domain_name', $extension, $message);
+
+        $this->app->resolving(Factory::class, function (Factory $factory) use ($extension,) {
+            $message = 'This is not a valid domain name.';
+
+            $factory->extend('alpha_dash_dot', $extension, $message);
+            $factory->extend('alpha-dash-dot', $extension, $message);
+        });
     }
 
     /**
@@ -129,7 +141,7 @@ class ValidationServiceProvider extends BaseProvider
      * which it is possible to parse out the international dialling code from the
      * rest of the phone number.
      */
-    protected function bootInternationalPhoneRule()
+    protected function bootInternationalPhoneRule(): void
     {
         /** @param LaravelValidator $validator */
         $extension = function ($attribute, $value, $parameters, $validator) {
@@ -185,12 +197,12 @@ class ValidationServiceProvider extends BaseProvider
             return true;
         };
 
-        $message = 'This is not a valid international phone number';
-
-        Validator::extend('international_phone', $extension, $message);
+        $this->app->resolving(Factory::class, function (Factory $factory) use ($extension) {
+            $factory->extend('international_phone', $extension, 'This is not a valid international phone number');
+        });
     }
 
-    protected function bootCountryCodeRule()
+    protected function bootCountryCodeRule(): void
     {
         $extension = function ($attribute, $value, $parameters, $validator) {
             try {
@@ -222,24 +234,29 @@ class ValidationServiceProvider extends BaseProvider
                 return false;
             }
         };
-        $message = 'This is not a valid country code.';
 
-        Validator::extend('country_code', $extension, $message);
+        $this->app->resolving(Factory::class, function (Factory $factory) use ($extension) {
+            $factory->extend('country_code', $extension, 'This is not a valid country code.');
+        });
     }
 
     protected function bootStepRule(): void
     {
-        Validator::extend('step', 'Upmind\ProvisionBase\Laravel\Validation\Rules\Step@validateStep');
-        Validator::replacer('step', 'Upmind\ProvisionBase\Laravel\Validation\Rules\Step@replaceStep');
+        $this->app->resolving(Factory::class, function (Factory $factory) {
+            $factory->extend('step', 'Upmind\ProvisionBase\Laravel\Validation\Rules\Step@validateStep');
+            $factory->replacer('step', 'Upmind\ProvisionBase\Laravel\Validation\Rules\Step@replaceStep');
+        });
     }
 
     protected function bootCertificatePemRule(): void
     {
-        Validator::extend(
-            'certificate_pem',
-            CertificatePem::class,
-            'The :attribute must be a certificate in PEM format'
-        );
+        $this->app->resolving(Factory::class, function (Factory $factory) {
+            $factory->extend(
+                'certificate_pem',
+                CertificatePem::class,
+                'The :attribute must be a certificate in PEM format'
+            );
+        });
     }
 
     /**

--- a/src/Laravel/ValidationServiceProvider.php
+++ b/src/Laravel/ValidationServiceProvider.php
@@ -16,6 +16,7 @@ use League\ISO3166\ISO3166;
 use libphonenumber\NumberParseException;
 use Propaganistas\LaravelPhone\Exceptions\NumberParseException as PropaganistasNumberParseException;
 use Upmind\ProvisionBase\Laravel\Validation\Rules\CertificatePem;
+use Upmind\ProvisionBase\Provider\DataSet\DataSet;
 use Upmind\ProvisionBase\Provider\DataSet\RuleParser;
 use Upmind\ProvisionBase\Provider\DataSet\Validator as DataSetValidator;
 
@@ -55,10 +56,14 @@ class ValidationServiceProvider extends BaseProvider
         $this->bootCertificatePemRule();
     }
 
-    protected function bootDataSetValidatorResolver()
+    protected function bootDataSetValidatorResolver(): void
     {
         /** @var \Illuminate\Validation\Factory $factory */
         $factory = Validator::getFacadeRoot();
+
+        // Set Validator Factory for our DataSet classes.
+        DataSet::setValidatorFactory($factory);
+
         $factory->resolver(function ($translator, $data, $rules, $messages, $customAttributes) use ($factory) {
             if (RuleParser::containsRule($rules, RuleParser::NESTED_DATA_SET_RULE)) {
                 return new DataSetValidator($factory, $translator, $data, $rules, $messages, $customAttributes);

--- a/src/Laravel/ValidationServiceProvider.php
+++ b/src/Laravel/ValidationServiceProvider.php
@@ -143,7 +143,14 @@ class ValidationServiceProvider extends BaseProvider
      */
     protected function bootInternationalPhoneRule(): void
     {
-        /** @param LaravelValidator $validator */
+        /**
+         * @param $attribute
+         * @param $value
+         * @param $parameters
+         * @param $validator
+         * @return bool
+         * @throws \Illuminate\Contracts\Container\BindingResolutionException
+         */
         $extension = function ($attribute, $value, $parameters, $validator) {
             if (!empty($parameters[0])) {
                 //validate phone number for the input country code
@@ -158,18 +165,16 @@ class ValidationServiceProvider extends BaseProvider
                     'phone' => sprintf('phone:%s', $countryCode)
                 ]);
 
-                if ($extraValidator->fails()) {
-                    if (!$this->manualCheckPhones($value)) {
-                        // manually adding an error will cause validation to fail with this specific error message
-                        $validator->errors()
-                            ->add(
-                                $attribute,
-                                $this->makeReplacements('This is not a valid :COUNTRY_CODE phone number', [
-                                    'attribute' => $attribute,
-                                    'country_code' => $countryCode,
-                                ])
-                            );
-                    }
+                if ($extraValidator->fails() && !$this->manualCheckPhones($value)) {
+                    // manually adding an error will cause validation to fail with this specific error message
+                    $validator->errors()
+                        ->add(
+                            $attribute,
+                            $this->makeReplacements('This is not a valid :COUNTRY_CODE phone number', [
+                                'attribute' => $attribute,
+                                'country_code' => $countryCode,
+                            ])
+                        );
                 }
 
                 return true;

--- a/src/Provider/DataSet/AboutData.php
+++ b/src/Provider/DataSet/AboutData.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Upmind\ProvisionBase\Provider\DataSet;
 
-use Upmind\ProvisionBase\Provider\DataSet\DataSet;
-
 /**
  * @property-read string $name Name of the provision category or provider
  * @property-read string $description Description of the provision category or provider

--- a/src/Provider/DataSet/DataSet.php
+++ b/src/Provider/DataSet/DataSet.php
@@ -7,6 +7,7 @@ namespace Upmind\ProvisionBase\Provider\DataSet;
 use ArrayAccess;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Support\Facades\Validator as ValidatorFactory;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Validation\ValidationException;
@@ -22,6 +23,8 @@ use Upmind\ProvisionBase\Exception\InvalidDataSetException;
  */
 abstract class DataSet implements ArrayAccess, JsonSerializable, Arrayable, Jsonable
 {
+    public static Factory $validatorFactory;
+
     /**
      * Input values with nested data sets expanded.
      *
@@ -56,7 +59,7 @@ abstract class DataSet implements ArrayAccess, JsonSerializable, Arrayable, Json
     protected $isValidated = false;
 
     /**
-     * Whether or not auto-validation is enabled for this data set instance.
+     * Whether auto-validation is enabled for this data set instance.
      *
      * @var bool
      */
@@ -85,6 +88,16 @@ abstract class DataSet implements ArrayAccess, JsonSerializable, Arrayable, Json
         $this->validationEnabled = $autoValidation;
 
         $this->fillNestedDataSets(); // cast values to data sets if appropriate
+    }
+
+    public static function getValidatorFactory(): Factory
+    {
+        return static::$validatorFactory ?? ValidatorFactory::getFacadeRoot();
+    }
+
+    public static function setValidatorFactory(Factory $validatorFactory): void
+    {
+        static::$validatorFactory = $validatorFactory;
     }
 
     /**
@@ -286,7 +299,7 @@ abstract class DataSet implements ArrayAccess, JsonSerializable, Arrayable, Json
      */
     protected function makeValidator($data, Rules $rules): Validator
     {
-        return ValidatorFactory::make($data, $rules->expand());
+        return self::getValidatorFactory()->make($data, $rules->expand());
     }
 
     /**

--- a/src/Provider/DataSet/DataSet.php
+++ b/src/Provider/DataSet/DataSet.php
@@ -52,7 +52,7 @@ abstract class DataSet implements ArrayAccess, JsonSerializable, Arrayable, Json
     protected $validator;
 
     /**
-     * Whether or not the data set has yet been validated.
+     * Whether the data set has been validated yet.
      *
      * @var bool
      */

--- a/src/Provider/DataSet/DataSet.php
+++ b/src/Provider/DataSet/DataSet.php
@@ -92,12 +92,16 @@ abstract class DataSet implements ArrayAccess, JsonSerializable, Arrayable, Json
 
     public static function getValidatorFactory(): Factory
     {
-        return static::$validatorFactory ?? ValidatorFactory::getFacadeRoot();
+        if (self::$validatorFactory === null) {
+            self::$validatorFactory = ValidatorFactory::getFacadeRoot();
+        }
+
+        return self::$validatorFactory;
     }
 
     public static function setValidatorFactory(Factory $validatorFactory): void
     {
-        static::$validatorFactory = $validatorFactory;
+        self::$validatorFactory = $validatorFactory;
     }
 
     /**

--- a/src/Provider/DataSet/DataSet.php
+++ b/src/Provider/DataSet/DataSet.php
@@ -23,7 +23,7 @@ use Upmind\ProvisionBase\Exception\InvalidDataSetException;
  */
 abstract class DataSet implements ArrayAccess, JsonSerializable, Arrayable, Jsonable
 {
-    public static Factory $validatorFactory;
+    private static Factory $validatorFactory;
 
     /**
      * Input values with nested data sets expanded.

--- a/src/Provider/DataSet/RuleParser.php
+++ b/src/Provider/DataSet/RuleParser.php
@@ -6,7 +6,6 @@ namespace Upmind\ProvisionBase\Provider\DataSet;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationRuleParser;
 use Illuminate\Validation\Validator as LaravelValidator;
@@ -25,10 +24,7 @@ class RuleParser
      */
     public const NESTED_DATA_SET_RULE = 'upmind_nested_data_set';
 
-    /**
-     * @var LaravelValidator|null
-     */
-    protected static $validator;
+    protected static ?LaravelValidator $validator = null;
 
     /**
      * Parse the given data set rules, expanding nested references to other data
@@ -382,6 +378,10 @@ class RuleParser
 
     protected static function getValidator(): LaravelValidator
     {
-        return self::$validator = (self::$validator ?? Validator::make([], []));
+        if (self::$validator === null) {
+            self::$validator = DataSet::getValidatorFactory()->make([], []);
+        }
+
+        return self::$validator;
     }
 }

--- a/src/Provider/DataSet/RuleParser.php
+++ b/src/Provider/DataSet/RuleParser.php
@@ -76,12 +76,10 @@ class RuleParser
      */
     public static function expandWildcardRules(array $rawRules, array $data): array
     {
-        // The primary purpose of this parser is to expand any "*" rules to the all
-        // of the explicit rules needed for the given data. For example the rule
+        // The primary purpose of this parser is to expand any "*" rules
+        // to all the explicit rules needed for the given data. For example the rule
         // names.* would get expanded to names.0, names.1, etc. for this data.
-        $parsed = (new ValidationRuleParser($data))->explode($rawRules);
-
-        return $parsed->rules;
+        return (new ValidationRuleParser($data))->explode($rawRules)->rules;
     }
 
     /**

--- a/tests/Unit/Provider/DataSet/AboutDataTest.php
+++ b/tests/Unit/Provider/DataSet/AboutDataTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit\Provider\DataSet;
+
+use Illuminate\Contracts\Translation\Translator;
+use Illuminate\Contracts\Validation\Factory;
+use Illuminate\Validation\Validator;
+use Illuminate\Support\MessageBag;
+use Illuminate\Validation\ValidationException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Upmind\ProvisionBase\Exception\InvalidDataSetException;
+use Upmind\ProvisionBase\Provider\DataSet\AboutData;
+
+class AboutDataTest extends TestCase
+{
+    private MockObject&Factory $validatorFactory;
+
+    protected function setUp(): void
+    {
+        $this->validatorFactory = $this->createMock(Factory::class);
+    }
+
+    /**
+     * This is an example test, performed to confirm decoupling from Laravel's Validator Facade.
+     * It asserts that an InvalidDataSetException is thrown when validation fails.
+     *
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function test_invalid_data_set_exception_thrown_on_validation_failure(): void
+    {
+        $this->expectException(InvalidDataSetException::class);
+
+        $translator = $this->createMock(Translator::class);
+        $validator = $this->createMock(Validator::class);
+
+        $messageBag = new MessageBag();
+        $messageBag->add('name', 'The name field is required.');
+
+        $validator->method('getTranslator')->willReturn($translator);
+        $validator->method('errors')->willReturn($messageBag);
+        $validator->method('validate')->willThrowException(new ValidationException($validator));
+
+        $this->validatorFactory->method('make')->willReturn($validator);
+
+        AboutData::setValidatorFactory($this->validatorFactory);
+
+        $aboutData = new AboutData();
+
+        $aboutData->validate();
+    }
+}


### PR DESCRIPTION
Closes #50 
Closes #12 

- Allows custom validator setter to prevent using the factory, this helps with easier Unit Tests
- Removes all Facades Dependencies from the Larave Service Provider
- Set validator factory via service provider once & forget
- Added Init Unit Testing to confirm functionality without Facade
- Added github actions workflow for tests
- Updated static analysis github actions workflow to cover `v5-dev` branch